### PR TITLE
(BKR-1155) Add a Prefered SSH Connection Method

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -243,6 +243,10 @@ module Beaker
           @logger.debug "No disks to add for #{hostname}"
         end
       end
+
+      # Override SSH connection method if not already explicitly configured.
+      # IP addresses can change across reboots with vmpooler so prefer DNS based resolution
+      @hosts.each {|h| h[:connection_method] ||= 'vmhostname'}
     end
 
     def cleanup

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -142,6 +142,31 @@ module Beaker
                           /Vmpooler\.provision - requested VM templates \[[^\,]*\] not available/
              ) # should be only one item in the list, no commas
       end
+
+      it 'ignores the ssh connection type when explicitly configured' do
+        hosts = make_hosts
+        hosts.each {|h| h[:connection_method] = 'explicit_connection_type'}
+
+        vmpooler = Beaker::Vmpooler.new( hosts, make_opts )
+        vmpooler.provision
+
+        hosts = vmpooler.instance_variable_get( :@hosts )
+        hosts.each do | host |
+          expect(host[:connection_method]).to be === 'explicit_connection_type'
+        end
+      end
+
+      it 'sets the ssh connection type to vmhostname when not explicitly configured' do
+        #p make_hosts
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        vmpooler.provision
+
+        hosts = vmpooler.instance_variable_get( :@hosts )
+        hosts.each do | host |
+         # p host
+          expect(host[:connection_method]).to be === 'vmhostname'
+        end
+      end
     end
 
     describe "#cleanup" do


### PR DESCRIPTION
BKR-834 made vmhostname the default lookup method for SSH connections but this
broke hypervisors which don't have DNS support e.g. OpenStack.  By setting the
connection method in the hypervisor we can choose where to prefer specific
methods.