### PR TITLE
(BKR-1155) Override beaker's default ssh connection preference

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -52,7 +52,7 @@ module Beaker
       YAML.load_file(dot_fog)
     end
 
-    def connection_preference
+    def connection_preference(host)
       ['vmhostname', 'ip', 'hostname']
     end
 


### PR DESCRIPTION
[skip ci]