### PR TITLE
(maint) Add option for BEAKER_HOSTS file to be pre-generated in acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 # don't want to create a transitive dependency
 group :acceptance_testing do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
+  gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.3.0')
 end
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,12 @@ Runs the base beaker acceptance test using the hypervisor library
     beaker_gem_spec = Gem::Specification.find_by_name('beaker')
     beaker_gem_dir = beaker_gem_spec.gem_dir
     beaker_test_base_dir = File.join(beaker_gem_dir, 'acceptance/tests/base')
+    beaker_hosts = ENV['BEAKER_HOSTS'] || 'redhat7-64af-64default.mdcal'
     load_path_option = File.join(beaker_gem_dir, 'acceptance/lib')
     sh("beaker",
        "--tests", beaker_test_base_dir,
        "--log-level", "verbose",
-       "--hosts", "redhat7-64af-redhat7-64default.mdcal",
+       "--hosts", beaker_hosts,
        "--load-path", load_path_option,
        "--keyfile", ENV['KEY'] || "#{ENV['HOME']}/.ssh/id_rsa-acceptance")
   end


### PR DESCRIPTION
Before, the host configuration was hard-coded. Added an option
to specify an ENV var in order to use a different string or a
pre-generated hostfile.

This also allows us to use abs in production, so that has been added
to the Gemfile