### PR TITLE
(MAINT) fix connection preferences

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -53,7 +53,7 @@ module Beaker
     end
 
     def connection_preference(host)
-      ['vmhostname', 'ip', 'hostname']
+      [:vmhostname, :ip, :hostname]
     end
 
     def check_url url


### PR DESCRIPTION
![](https://www.bingeclock.com/memes/simpsons___facepalm_doh.jpg)

Previously, beaker-vmpooler defined its
connection preferences as string options, but
beaker provides defaults as symbols. This ends
with beaker saying that it doesn't support methods
that it does due to the mismatch. This will get
rid of those messages, as the provided methods
will be symbols, matching what beaker expects