### PR TITLE
(MAINT) Drop MockVsphereHelper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ end
 # don't want to create a transitive dependency
 group :acceptance_testing do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
-  # gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.3.0')
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 # don't want to create a transitive dependency
 group :acceptance_testing do
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
-  gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.3.0')
+  # gem "beaker-abs", *location_for(ENV['ABS_VERSION'] || '~> 0.3.0')
 end
 
 

--- a/beaker-vmpooler.gemspec
+++ b/beaker-vmpooler.gemspec
@@ -20,7 +20,12 @@ Gem::Specification.new do |s|
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'fakefs', '~> 0.6'
+  # pin fakefs for Ruby < 2.3
+  if RUBY_VERSION < "2.3"
+    s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14'
+  else
+    s.add_development_dependency 'fakefs', '~> 0.6'
+  end
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -143,14 +143,14 @@ module Beaker
     describe "#cleanup" do
 
       it "cleans up hosts in the pool" do
-        mock_http = MockNet::HTTP.new("host", "port")
+        mock_http = MockNet::HTTP.new( "host", "port" )
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
         vmpooler.provision
         vm_count = vmpooler.instance_variable_get( :@hosts ).count
 
-        expect( Net::HTTP ).to receive( :new ).exactly(vm_count).times.and_return( mock_http )
-        expect( mock_http ).to receive( :request ).exactly(vm_count).times
-        expect( Net::HTTP::Delete ).to receive( :new ).exactly(vm_count).times
+        expect( Net::HTTP ).to receive( :new ).exactly( vm_count ).times.and_return( mock_http )
+        expect( mock_http ).to receive( :request ).exactly( vm_count ).times
+        expect( Net::HTTP::Delete ).to receive( :new ).exactly( vm_count ).times
         expect{ vmpooler.cleanup }.to_not raise_error
       end
     end
@@ -159,10 +159,6 @@ module Beaker
   describe Vmpooler do
 
     before :each do
-      vms = make_hosts()
-      MockVsphereHelper.set_config( fog_file_contents )
-      MockVsphereHelper.set_vms( vms )
-      stub_const( "VsphereHelper", MockVsphereHelper )
       stub_const( "Net", MockNet )
       allow( JSON ).to receive( :parse ) do |arg|
         arg

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -4,10 +4,6 @@ module Beaker
   describe Vmpooler do
 
     before :each do
-      vms = make_hosts()
-      MockVsphereHelper.set_config( fog_file_contents )
-      MockVsphereHelper.set_vms( vms )
-      stub_const( "VsphereHelper", MockVsphereHelper )
       stub_const( "Net", MockNet )
       allow( JSON ).to receive( :parse ) do |arg|
         arg
@@ -147,20 +143,15 @@ module Beaker
     describe "#cleanup" do
 
       it "cleans up hosts in the pool" do
-        MockVsphereHelper.powerOn
-
+        mock_http = MockNet::HTTP.new("host", "port")
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
-        allow( vmpooler ).to receive( :require ).and_return( true )
-        allow( vmpooler ).to receive( :sleep ).and_return( true )
         vmpooler.provision
-        vmpooler.cleanup
+        vm_count = vmpooler.instance_variable_get( :@hosts ).count
 
-        hosts = vmpooler.instance_variable_get( :@hosts )
-        hosts.each do | host |
-          name = host.name
-          vm = MockVsphereHelper.find_vm( name )
-          expect( vm.runtime.powerState ).to be === "poweredOn" #handed back to the pool, stays on
-        end
+        expect( Net::HTTP ).to receive( :new ).exactly(vm_count).times.and_return( mock_http )
+        expect( mock_http ).to receive( :request ).exactly(vm_count).times
+        expect( Net::HTTP::Delete ).to receive( :new ).exactly(vm_count).times
+        expect{ vmpooler.cleanup }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
No longer relevant since vmpooler replaced vcloudpooled.