### PR TITLE
(maint) random backoff strategy

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -169,7 +169,7 @@ module Beaker
           @logger.debug("Retrying provision for vmpooler host after waiting #{wait} second(s)")
           sleep wait
           waited += wait
-          last_wait, wait = wait, last_wait + wait
+          last_wait, wait = wait, [last_wait + wait, 15].min + rand(5)
           retry
         end
         report_and_raise(@logger, e, 'Vmpooler.provision')


### PR DESCRIPTION
The retry logic for VMPooler has two issues. 1) Waiting longer than
VMPooler takes to refill the pool to retry introduces excessive delays,
and 2) waiting for a deterministic amount of time means that processes
started at the same time stay in sync causing peak loads.

This change caps the wait time at 15 seconds plus a random wait time,
addressing both issues.