### PR TITLE
(maint) Fix the API URL for adding disks

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -274,7 +274,7 @@ module Beaker
       end
 
       begin
-        uri = URI.parse(@options[:pooling_api] + '/api/v1/vm/' + hostname + '/disk/' + disk_size.to_s)
+        uri = URI.parse(@options[:pooling_api] + '/vm/' + hostname + '/disk/' + disk_size.to_s)
 
         http = Net::HTTP.new(uri.host, uri.port)
         request = Net::HTTP::Post.new(uri.request_uri)


### PR DESCRIPTION
The pooling_api variable already contains /api/v1 so remove this from
the disk API URL so we don't end up with it twice