### PR TITLE
(PUP-11786) Beaker 5 compatibility

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gemspec :development_group => :acceptance_testing
 
-
-
 def location_for(place, fake_version = nil)
   if place =~ /^(git:[^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
@@ -14,15 +12,13 @@ def location_for(place, fake_version = nil)
   end
 end
 
-
 # We don't put beaker in as a test dependency because we
 # don't want to create a transitive dependency
 group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5.0')
   gem "beaker-abs"
 end
 
-
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/beaker-vmpooler.gemspec
+++ b/beaker-vmpooler.gemspec
@@ -20,12 +20,7 @@ Gem::Specification.new do |s|
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
-  # pin fakefs for Ruby < 2.3
-  if RUBY_VERSION < "2.3"
-    s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14'
-  else
-    s.add_development_dependency 'fakefs', '~> 0.6'
-  end
+  s.add_development_dependency 'fakefs', '~> 2.4'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Vox Pupuli has released Beaker 5, which drops older (< 2.7) Ruby compatibility and adds compatibility for Ruby 3.2

This commit adds testing for Ruby 3.2, sets the dependency on Beaker to ~> 5.0, replaces the File#exists? method that's been deprecated since Ruby 2.7 and removed in 3.2, and updates the dependency on FakeFS to the same version that Beaker uses (FakeFS ~> 2.4).