### PR TITLE
(PA-9008) Allow beaker 7 in development/testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 # We don't put beaker in as a test dependency because we
 # don't want to create a transitive dependency
 group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 5.0', '< 7')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 5.0', '< 8')
   gem "beaker-abs"
 end
 


### PR DESCRIPTION
## Summary
- Relaxes the beaker upper bound in the Gemfile from `< 7` to `< 8` to allow development and testing with beaker 7.
- The gemspec has no beaker constraint, so this only affects the dev/test Gemfile.

## Test plan
- [ ] Verify `bundle install` resolves successfully with beaker 7
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)